### PR TITLE
Mt 6636 add exception to tracking

### DIFF
--- a/lib/event_tracker/tracker.rb
+++ b/lib/event_tracker/tracker.rb
@@ -16,8 +16,11 @@ module EventTracker
       true
     end
 
-    def track(event_name, event_label, properties = {})
-      @trackers.each { |tracker| tracker.track(event_name, event_label, context_with_(properties)) }
+    def track(event_name, event_label, properties = {}, options = {})
+      @trackers.each do |tracker| 
+        next if options[:except].include?(tracker.class.downcase)
+        tracker.track(event_name, event_label, context_with_(properties))
+      end
     end
 
     private

--- a/lib/event_tracker/tracker.rb
+++ b/lib/event_tracker/tracker.rb
@@ -18,7 +18,8 @@ module EventTracker
 
     def track(event_name, event_label, properties = {}, options = {})
       @trackers.each do |tracker| 
-        next if options[:except].include?(tracker.class.downcase)
+        next if options[:except].include?(tracker.type)
+)
         tracker.track(event_name, event_label, context_with_(properties))
       end
     end

--- a/lib/event_tracker/trackers/base.rb
+++ b/lib/event_tracker/trackers/base.rb
@@ -5,6 +5,12 @@ module EventTracker
         @doer_id = doer_id
       end
 
+      # For programmatic determination of class/type for purposes such as
+      # excepting trackers, e.g., the Mixpanel tracker type is 'mixpanel'.
+      def type
+        self.class.to_s.split(':').last.downcase
+      end
+
       def track(event_name, event_label, properties)
         raise NotImplementedError, 'Implement in adapter'
       end


### PR DESCRIPTION
Allows exception of trackers on a per-call basis, in support of Returnly-6636.