### PR TITLE
Add base .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+insert_final_newline = false


### PR DESCRIPTION
# Ticket 🎫
:link: [Jira ticket](https://returnly.atlassian.net/browse/RETURN-7656)

<!-- Provide a brief description of the change and its impact -->
# Context 📓

We've been having trouble with different editors formatting lines with different configurations.

One way to standardized the editor behaviour is adding a `.editorconfig` file to the root of each project, and ensuring all team members have the [Editorconfig plugin](https://editorconfig.org/#download) installed on the IDE/editor of their choice.

Rubymine has the plugin installed by default, which is supposedly the preferred IDE.
