### PR TITLE
Remove tracking to Mixpanel by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ EventTracker.configure do |config|
 end
 ```
 
-This will automatically register the included `Mixpanel` tracker.
+Register your tracker
+
+```ruby
+def mixpanel_tracker
+  @mixpanel_tracker ||= begin
+    tracker = EventTracker::Trackers::Mixpanel.new(EventTracker.configuration.mixpanel_project_token)
+    tracker.register_tracker(EventTracker::Trackers::Mixpanel)
+    tracker
+  end
+end
+```
 
 ### Adding a custom tracker
 Create a `Tracker` and corresponding `Job` in your project like so:

--- a/lib/event_tracker/tracker.rb
+++ b/lib/event_tracker/tracker.rb
@@ -6,7 +6,6 @@ module EventTracker
       @trackers = []
 
       register_tracker EventTracker::Trackers::Development if development?
-      register_tracker EventTracker::Trackers::Mixpanel if mixpanel?
     end
 
     def register_tracker(tracker)
@@ -29,10 +28,6 @@ module EventTracker
 
     def development?
       Rails.env.development?
-    end
-
-    def mixpanel?
-      EventTracker.configuration.mixpanel_project_token.present?
     end
   end
 end

--- a/lib/event_tracker/version.rb
+++ b/lib/event_tracker/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EventTracker
-  VERSION = "1.0.0"
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
# Ticket 🎫
:link: [Jira ticket](https://returnly.atlassian.net/browse/RETURN-7778)

<!-- Provide a brief description of the change and its impact -->
# Context 📓 
We want to remove all the events not used in the RMA details page by returnly admins to lower our mixpanel usage.

In the future, if we want to track an event in Mixpanel, we need to register the Mixpanel Tracker in the application that is generating the event. 

<!-- If the change is visual, include a screenshot or GIF -->
# Preview 👁
